### PR TITLE
Fix issue #2

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -56,7 +56,7 @@ func parseLineForProtocol(line string, ipVersion int) (*protocol, bool) {
 	}
 
 	proto := parseProto(match[2])
-	up := parseState(match[6], proto)
+	up := parseState(match[4], proto)
 	ut := parseUptime(match[5])
 	p := &protocol{proto: proto, name: match[1], ipVersion: ipVersion, up: up, uptime: ut, attributes: make(map[string]interface{})}
 
@@ -84,7 +84,7 @@ func parseLineForRoutes(line string, p *protocol) {
 }
 
 func parseState(state string, proto int) int {
-	if proto == OSPF || state == "Established" {
+	if state == "up" {
 		return 1
 	} else {
 		return 0


### PR DESCRIPTION
bird already provides information iff a protocol is up or not. Lets use them instead of flawky protocol state. The protocol state machine is described in the bird source code: https://github.com/BIRD/bird/blob/7a855725f2ffde508da0c7ee01dc1bcd6e0a5d93/nest/protocol.h#L290 (line 290 in nest/protocol.h currently). Therefore, only "up" should be considered safe.
The problem with using "Established" for BGP and treat all OSPF sessions up is described in issue #2, as one might administratively shut down a protocol.