### PR TITLE
metrics: allow label_strategy to be implemented as api

### DIFF
--- a/metrics/default_label_strategy.go
+++ b/metrics/default_label_strategy.go
@@ -7,11 +7,11 @@ import (
 type DefaultLabelStrategy struct {
 }
 
-func (*DefaultLabelStrategy) labelNames() []string {
+func (*DefaultLabelStrategy) LabelNames() []string {
 	return []string{"name", "proto", "ip_version"}
 }
 
-func (*DefaultLabelStrategy) labelValues(p *protocol.Protocol) []string {
+func (*DefaultLabelStrategy) LabelValues(p *protocol.Protocol) []string {
 	return []string{p.Name, protoString(p), p.IpVersion}
 }
 

--- a/metrics/generic_exporter.go
+++ b/metrics/generic_exporter.go
@@ -43,7 +43,7 @@ func NewGenericProtocolMetricExporter(prefix string, newNaming bool, labelStrate
 }
 
 func (m *GenericProtocolMetricExporter) initDesc(prefix string, newNaming bool) {
-	labels := m.labelStrategy.labelNames()
+	labels := m.labelStrategy.LabelNames()
 	m.upDesc = prometheus.NewDesc(prefix+"_up", "Protocol is up", labels, nil)
 
 	if newNaming {
@@ -111,7 +111,7 @@ func (m *GenericProtocolMetricExporter) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (m *GenericProtocolMetricExporter) Export(p *protocol.Protocol, ch chan<- prometheus.Metric) {
-	l := m.labelStrategy.labelValues(p)
+	l := m.labelStrategy.LabelValues(p)
 	ch <- prometheus.MustNewConstMetric(m.upDesc, prometheus.GaugeValue, float64(p.Up), l...)
 	ch <- prometheus.MustNewConstMetric(m.importCountDesc, prometheus.GaugeValue, float64(p.Imported), l...)
 	ch <- prometheus.MustNewConstMetric(m.exportCountDesc, prometheus.GaugeValue, float64(p.Exported), l...)

--- a/metrics/label_strategy.go
+++ b/metrics/label_strategy.go
@@ -3,6 +3,6 @@ package metrics
 import "github.com/czerwonk/bird_exporter/protocol"
 
 type LabelStrategy interface {
-	labelNames() []string
-	labelValues(p *protocol.Protocol) []string
+	LabelNames() []string
+	LabelValues(p *protocol.Protocol) []string
 }

--- a/metrics/legacy_label_strategy.go
+++ b/metrics/legacy_label_strategy.go
@@ -5,10 +5,10 @@ import "github.com/czerwonk/bird_exporter/protocol"
 type LegacyLabelStrategy struct {
 }
 
-func (*LegacyLabelStrategy) labelNames() []string {
+func (*LegacyLabelStrategy) LabelNames() []string {
 	return []string{"name"}
 }
 
-func (*LegacyLabelStrategy) labelValues(p *protocol.Protocol) []string {
+func (*LegacyLabelStrategy) LabelValues(p *protocol.Protocol) []string {
 	return []string{p.Name}
 }


### PR DESCRIPTION
I use this exporter as an api, and I need to implement another
custom label strategy. Purpose being to habe business logic in
those labels (datacenter, ...).

Because the interface is private, this can not be implemented
elsewhere. This commit makes it public.