### PR TITLE
Use debian:stretch-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ workdir ${GOPATH}/src/github.com/czerwonk/bird_exporter
 copy . .
 run make deps build && cp bird_exporter /bird_exporter
 
-from golang:1.10
+from debian:stretch-slim
 copy --from=builder /bird_exporter /bird_exporter
 entrypoint ["/bird_exporter"]


### PR DESCRIPTION
* debian:stretch-slim is 55 Mb
* golang:1.10 is 730 Mb
* resulting image is now 67 Mb
* could be made even smaller by building a static binary

/cc @oyiu-dw 

