### PR TITLE
change Entrypoint format to allow passing arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /app
 COPY --from=builder /go/src/github.com/czerwonk/bird_exporter/app bird_exporter
 EXPOSE 9324
 
-ENTRYPOINT ./bird_exporter
+ENTRYPOINT ["/app/bird_exporter"]


### PR DESCRIPTION
Using the shell format prevents handing over arguments to the bird exporter using the format:

```
docker run bird_exporter -format.new=true ...
```

as well as using the `args:` in the container definition in Kubernetes.
Using the exec form of ENTRYPOINT changes the behaviour as well as enable respecting SIGTERM signals.

[1]: https://docs.docker.com/engine/reference/builder/#entrypoint