### PR TITLE
Parse uptime with timezone info

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -158,7 +158,7 @@ func parseUptime(value string) int {
 }
 
 func parseUptimeForIso(s string) int {
-	start, err := time.Parse("2006-01-02 15:04:05", s)
+	start, err := time.ParseInLocation("2006-01-02 15:04:05", s, time.Local)
 	if err != nil {
 		log.Errorln(err)
 		return 0


### PR DESCRIPTION
Hello,

The time in `birdc sh pro` is timezone related value. (I am using iso long as the README.md suggested)
For example, my VPS run in Asia/Shanghai timezone, the time in `birdc sh pro` are UTC+8.

`time.Parse` will parse the time string to UTC, which will result in `int(time.Since(start).Seconds())` become a minus value.

```
# HELP bird_protocol_uptime Uptime of the protocol in seconds
# TYPE bird_protocol_uptime gauge
bird_protocol_uptime{export_filter="(unnamed)",import_filter="ACCEPT",ip_version="4",name="O_OSPF",proto="OSPF"} -1076
bird_protocol_uptime{export_filter="(unnamed)",import_filter="ACCEPT",ip_version="6",name="A",proto="BGP"} -1124
bird_protocol_uptime{export_filter="(unnamed)",import_filter="REJECT",ip_version="4",name="B",proto="BGP"} -1080
bird_protocol_uptime{export_filter="(unnamed)",import_filter="REJECT",ip_version="6",name="C",proto="BGP"} -1081
```

This PR change `time.Parse` to `time.ParseInLocation`, the newer one will parse the time string to the correct timezone, and solve the minus problem.

Thanks.