### PR TITLE
Add bgp state metrics

### DIFF
--- a/client/bird_client.go
+++ b/client/bird_client.go
@@ -51,6 +51,16 @@ func (c *BirdClient) GetOSPFAreas(protocol *protocol.Protocol) ([]*protocol.Ospf
 	return parser.ParseOspf(b), nil
 }
 
+// GetBGPStates retrieves BGP state information from bird
+func (c *BirdClient) GetBGPStates(protocol *protocol.Protocol) (*protocol.BgpState, error) {
+	sock := c.socketFor(protocol.IPVersion)
+	b, err := birdsocket.Query(sock, fmt.Sprintf("show protocols all %s", protocol.Name))
+	if err != nil {
+		return nil, err
+	}
+	return parser.ParseBgpState(b), nil
+}
+
 func (c *BirdClient) protocolsFromBird(ipVersions []string) ([]*protocol.Protocol, error) {
 	protocols := make([]*protocol.Protocol, 0)
 

--- a/client/client.go
+++ b/client/client.go
@@ -10,4 +10,7 @@ type Client interface {
 
 	// GetOSPFAreas retrieves OSPF specific information from bird
 	GetOSPFAreas(protocol *protocol.Protocol) ([]*protocol.OspfArea, error)
+
+	// GetBGPStates retrieves BGP state information from bird
+	GetBGPStates(protocol *protocol.Protocol) (*protocol.BgpState, error)
 }

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -49,7 +49,7 @@ func exportersForLegacy(c *client.BirdClient) map[int][]metrics.MetricExporter {
 	l := metrics.NewLegacyLabelStrategy()
 
 	return map[int][]metrics.MetricExporter{
-		protocol.BGP:    {metrics.NewLegacyMetricExporter("bgp4_session", "bgp6_session", l)},
+		protocol.BGP:    {metrics.NewLegacyMetricExporter("bgp4_session", "bgp6_session", l), metrics.NewBGPStateExporter("", c)},
 		protocol.Direct: {metrics.NewLegacyMetricExporter("direct4", "direct6", l)},
 		protocol.Kernel: {metrics.NewLegacyMetricExporter("kernel4", "kernel6", l)},
 		protocol.OSPF:   {metrics.NewLegacyMetricExporter("ospf", "ospfv3", l), metrics.NewOSPFExporter("", c)},
@@ -62,7 +62,7 @@ func exportersForDefault(c *client.BirdClient, descriptionLabels bool) map[int][
 	e := metrics.NewGenericProtocolMetricExporter("bird_protocol", true, l)
 
 	return map[int][]metrics.MetricExporter{
-		protocol.BGP:    {e},
+		protocol.BGP:    {e, metrics.NewBGPStateExporter("bird_", c)},
 		protocol.Direct: {e},
 		protocol.Kernel: {e},
 		protocol.OSPF:   {e, metrics.NewOSPFExporter("bird_", c)},

--- a/metrics/bgp_state_exporter.go
+++ b/metrics/bgp_state_exporter.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"github.com/czerwonk/bird_exporter/client"
+	"github.com/czerwonk/bird_exporter/protocol"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+type bgpStateMetricExporter struct {
+	prefix string
+	client client.Client
+}
+
+// NewBGPStateExporter creates a new MetricExporter for BGP metrics
+func NewBGPStateExporter(prefix string, client client.Client) MetricExporter {
+	return &bgpStateMetricExporter{prefix: prefix, client: client}
+}
+
+func (m *bgpStateMetricExporter) Describe(ch chan<- *prometheus.Desc) {
+}
+
+func (m *bgpStateMetricExporter) Export(p *protocol.Protocol, ch chan<- prometheus.Metric, newFormat bool) {
+
+	labels := []string{"name", "proto", "state"}
+	bgpstateDesc := prometheus.NewDesc(m.prefix+"bgp_state_count", "Number of BGP connections at each state", labels, nil)
+	state, err := m.client.GetBGPStates(p)
+	if err != nil {
+		log.Errorln(err)
+		return
+	}
+	if state != nil {
+		l := []string{state.Name, "BGP", state.State}
+		ch <- prometheus.MustNewConstMetric(bgpstateDesc, prometheus.GaugeValue, float64(1), l...)
+	}
+}

--- a/parser/bgp_state.go
+++ b/parser/bgp_state.go
@@ -1,0 +1,49 @@
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/czerwonk/bird_exporter/protocol"
+)
+
+var (
+	nameRegex     *regexp.Regexp
+	bgpStateRegex *regexp.Regexp
+)
+
+type bgpStateContext struct {
+	line    string
+	current *protocol.BgpState
+}
+
+func init() {
+	bgpStateRegex = regexp.MustCompile(`^(?:1002\-)?([^\s]+)\s+(MRT|BGP|BFD|OSPF|RPKI|RIP|RAdv|Pipe|Perf|Direct|Babel|Device|Kernel|Static)\s+([^\s]+)\s+([^\s]+)\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|[^\s]+)\s+(Idle|Connect|Active|OpenSent|OpenConfirm|Established|Close)(?:\s+(.*?))?$`)
+}
+
+func ParseBgpState(data []byte) *protocol.BgpState {
+	reader := bytes.NewReader(data)
+	scanner := bufio.NewScanner(reader)
+
+	c := &bgpStateContext{
+		current: nil,
+	}
+
+	for scanner.Scan() {
+		c.line = strings.TrimRight(scanner.Text(), " ")
+		if c.line == "" {
+			c.current = nil
+		}
+		m := bgpStateRegex.FindStringSubmatch(c.line)
+		if m != nil {
+			s := &protocol.BgpState{Name: m[1]}
+			c.current = s
+			c.current.State = m[6]
+			break
+		}
+	}
+
+	return c.current
+}

--- a/protocol/bgp_state.go
+++ b/protocol/bgp_state.go
@@ -1,0 +1,6 @@
+package protocol
+
+type BgpState struct {
+	Name  string
+	State string
+}


### PR DESCRIPTION
This patch adds bgp state metrics as follows:
http://XXX:9324/metrics

bird_bgp_state{name="uplink0",proto="BGP",state="Active"} 1
bird_bgp_state{name="uplink1",proto="BGP",state="Idle"} 1