### PR TITLE
Add basic support for the Babel protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ https://grafana.com/dashboards/5259
 ## Features
 * BGP session state
 * OSPF neighbor/interface count
-* imported / exported / filtered prefix counts / route state changes (BGP, OSPF, Kernel, Static, Device, Direct)
+* imported / exported / filtered prefix counts / route state changes (BGP, OSPF, Kernel, Static, Device, Direct, Babel)
 * protocol uptimes (BGP, OSPF)
 
 ## Third Party Components

--- a/bird_exporter.1.md
+++ b/bird_exporter.1.md
@@ -60,6 +60,9 @@ bird_exporter must have read/write permission to access the BIRD Unix sockets.
 **-proto.static**
     Enables metrics for protocol Static
 
+**-proto.babel**
+    Enables metrics for protocol Babel
+
 **-version**
     Print version information
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	enableKernel  = flag.Bool("proto.kernel", true, "Enables metrics for protocol Kernel")
 	enableStatic  = flag.Bool("proto.static", true, "Enables metrics for protocol Static")
 	enableDirect  = flag.Bool("proto.direct", true, "Enables metrics for protocol Direct")
+	enableBabel   = flag.Bool("proto.babel", true, "Enables metrics for protocol Babel")
 	// pre bird 2.0
 	bird6Socket       = flag.String("bird.socket6", "/var/run/bird6.ctl", "Socket to communicate with bird6 routing daemon (not compatible with -bird.v2)")
 	birdEnabled       = flag.Bool("bird.ipv4", true, "Get protocols from bird (not compatible with -bird.v2)")
@@ -113,6 +114,9 @@ func enabledProtocols() int {
 	}
 	if *enableDirect {
 		res |= protocol.Direct
+	}
+	if *enableBabel {
+		res |= protocol.Babel
 	}
 
 	return res

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -54,6 +54,7 @@ func exportersForLegacy(c *client.BirdClient) map[int][]metrics.MetricExporter {
 		protocol.Kernel: {metrics.NewLegacyMetricExporter("kernel4", "kernel6", l)},
 		protocol.OSPF:   {metrics.NewLegacyMetricExporter("ospf", "ospfv3", l), metrics.NewOSPFExporter("", c)},
 		protocol.Static: {metrics.NewLegacyMetricExporter("static4", "static6", l)},
+		protocol.Babel:  {metrics.NewLegacyMetricExporter("babel4", "babel6", l)},
 	}
 }
 
@@ -67,6 +68,7 @@ func exportersForDefault(c *client.BirdClient, descriptionLabels bool) map[int][
 		protocol.Kernel: {e},
 		protocol.OSPF:   {e, metrics.NewOSPFExporter("bird_", c)},
 		protocol.Static: {e},
+		protocol.Babel:  {e},
 	}
 }
 

--- a/metrics/default_label_strategy.go
+++ b/metrics/default_label_strategy.go
@@ -78,6 +78,8 @@ func protoString(p *protocol.Protocol) string {
 		return "Kernel"
 	case protocol.Direct:
 		return "Direct"
+	case protocol.Babel:
+		return "Babel"
 	}
 
 	return ""

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -126,6 +126,8 @@ func parseProto(val string) int {
 		return protocol.Kernel
 	case "Static":
 		return protocol.Static
+	case "Babel":
+		return protocol.Babel
 	}
 
 	return protocol.PROTO_UNKNOWN

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -7,6 +7,7 @@ const (
 	Kernel        = 4
 	Static        = 8
 	Direct        = 16
+	Babel         = 32
 )
 
 type Protocol struct {


### PR DESCRIPTION
Thanks for writing the Prometheus bird exporter!

I use Bird with the Babel protocol.  This PR doesn't add a protocol specific parser, but does allow basic information about babel imported and exported routes etc. to be exposed.