### PR TITLE
Allow regex to extract labels from protocol description

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,10 +30,11 @@ var (
 	enableRPKI    = flag.Bool("proto.rpki", true, "Enables metrics for protocol RPKI")
 	enableBFD     = flag.Bool("proto.bfd", true, "Enables metrics for protocol BFD")
 	// pre bird 2.0
-	bird6Socket       = flag.String("bird.socket6", "/var/run/bird6.ctl", "Socket to communicate with bird6 routing daemon (not compatible with -bird.v2)")
-	birdEnabled       = flag.Bool("bird.ipv4", true, "Get protocols from bird (not compatible with -bird.v2)")
-	bird6Enabled      = flag.Bool("bird.ipv6", true, "Get protocols from bird6 (not compatible with -bird.v2)")
-	descriptionLabels = flag.Bool("format.description-labels", false, "Add labels from protocol descriptions.")
+	bird6Socket            = flag.String("bird.socket6", "/var/run/bird6.ctl", "Socket to communicate with bird6 routing daemon (not compatible with -bird.v2)")
+	birdEnabled            = flag.Bool("bird.ipv4", true, "Get protocols from bird (not compatible with -bird.v2)")
+	bird6Enabled           = flag.Bool("bird.ipv6", true, "Get protocols from bird6 (not compatible with -bird.v2)")
+	descriptionLabels      = flag.Bool("format.description-labels", false, "Add labels from protocol descriptions.")
+	descriptionLabelsRegex = flag.String("format.description-labels-regex", "(\\w+)=(\\w+)", "Regex to extract labels from protocol description")
 )
 
 func init() {

--- a/metric_collector.go
+++ b/metric_collector.go
@@ -61,7 +61,7 @@ func exportersForLegacy(c *client.BirdClient) map[protocol.Proto][]metrics.Metri
 }
 
 func exportersForDefault(c *client.BirdClient, descriptionLabels bool) map[protocol.Proto][]metrics.MetricExporter {
-	l := metrics.NewDefaultLabelStrategy(descriptionLabels)
+	l := metrics.NewDefaultLabelStrategy(descriptionLabels, *descriptionLabelsRegex)
 	e := metrics.NewGenericProtocolMetricExporter("bird_protocol", true, l)
 
 	return map[protocol.Proto][]metrics.MetricExporter{

--- a/metrics/default_label_strategy.go
+++ b/metrics/default_label_strategy.go
@@ -1,19 +1,21 @@
 package metrics
 
 import (
-	"strings"
+	"regexp"
 
 	"github.com/czerwonk/bird_exporter/protocol"
 )
 
 // DefaultLabelStrategy defines the labels to add to an metric and its data retrieval method
 type DefaultLabelStrategy struct {
-	descriptionLabels bool
+	descriptionLabels      bool
+	descriptionLabelsRegex string
 }
 
-func NewDefaultLabelStrategy(descriptionLabels bool) *DefaultLabelStrategy {
+func NewDefaultLabelStrategy(descriptionLabels bool, descriptionLabelsRegex string) *DefaultLabelStrategy {
 	return &DefaultLabelStrategy{
-		descriptionLabels: descriptionLabels,
+		descriptionLabels:      descriptionLabels,
+		descriptionLabelsRegex: descriptionLabelsRegex,
 	}
 }
 
@@ -21,7 +23,7 @@ func NewDefaultLabelStrategy(descriptionLabels bool) *DefaultLabelStrategy {
 func (d *DefaultLabelStrategy) LabelNames(p *protocol.Protocol) []string {
 	res := []string{"name", "proto", "ip_version", "import_filter", "export_filter"}
 	if d.descriptionLabels && p.Description != "" {
-		res = append(res, labelKeysFromDescription(p.Description)...)
+		res = append(res, labelKeysFromDescription(p.Description, d)...)
 	}
 
 	return res
@@ -31,34 +33,36 @@ func (d *DefaultLabelStrategy) LabelNames(p *protocol.Protocol) []string {
 func (d *DefaultLabelStrategy) LabelValues(p *protocol.Protocol) []string {
 	res := []string{p.Name, protoString(p), p.IPVersion, p.ImportFilter, p.ExportFilter}
 	if d.descriptionLabels && p.Description != "" {
-		res = append(res, labelValuesFromDescription(p.Description)...)
+		res = append(res, labelValuesFromDescription(p.Description, d)...)
 	}
 
 	return res
 }
 
-func labelKeysFromDescription(desc string) (res []string) {
-	for _, x := range strings.Split(desc, ",") {
-		tmp := strings.Split(x, "=")
-		if len(tmp) != 2 {
-			continue
-		}
-
-		res = append(res, strings.TrimSpace(tmp[0]))
+func labelKeysFromDescription(desc string, d *DefaultLabelStrategy) (res []string) {
+	reAllStringSubmatch := labelFindAllStringSubmatch(desc, d)
+	for _, submatch := range reAllStringSubmatch {
+		res = append(res, submatch[1])
 	}
 
 	return
 }
 
-func labelValuesFromDescription(desc string) (res []string) {
-	for _, x := range strings.Split(desc, ",") {
-		tmp := strings.Split(x, "=")
-		if len(tmp) != 2 {
-			continue
-		}
-
-		res = append(res, strings.TrimSpace(tmp[1]))
+func labelValuesFromDescription(desc string, d *DefaultLabelStrategy) (res []string) {
+	reAllStringSubmatch := labelFindAllStringSubmatch(desc, d)
+	for _, submatch := range reAllStringSubmatch {
+		res = append(res, submatch[2])
 	}
+
+	return
+}
+
+func labelFindAllStringSubmatch(desc string, d *DefaultLabelStrategy) (result [][]string) {
+
+	// Regex pattern captures "key: value" pair from the content.
+	pattern := regexp.MustCompile(d.descriptionLabelsRegex)
+
+	result = pattern.FindAllStringSubmatch(desc, -1)
 
 	return
 }


### PR DESCRIPTION
# Overview
The change allows parsing complex protocols descriptions using regex. Sample use cases:
- Original description is for human eyes and the rest is for labels
- Flexibility in separators, ways to group labels (e.g. brackets instead of separators), add comments

The details are below.

# Details
## Before the change
Currently [Prometheus's labels](https://prometheus.io/docs/concepts/data_model/) can be extracted from [BIRD protocol description](https://bird.network.cz/?get_doc&v=20&f=bird-3.html#ss3.3) if they use:
- '=' as key-value separator
- ',' as pair separator

For example:
~~~
"key1=value1,key2=value2"
~~~

## Proposed change
The regex-based functions find all occurrences of the pre-defined pattern in protocol description. Non-matching parts of the description are ignored. 

## Example
Description:
~~~
"For humans: some text; Labels: key1=value1, key2=value2"
~~~
Default regex pattern will add the following labels to the metric:
~~~
key1="value1",key2="value2"
~~~

## Effect on existing deployments
None. 

If new functionality is not activated (see "Usage" below), bird-exporter will work with the descriptions as before.

## Usage
Add new flag "format.description-labels-regex" to specify the regex. E.g.:
~~~
bird_exporter -format.description-labels="true" -format.description-labels-regex="(\\w+)=(\\w+)"
~~~