### PR TITLE
Add metric representing bird socket query result

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "1.4.1"
+const version string = "1.4.2"
 
 var (
 	showVersion   = flag.Bool("version", false, "Print version information.")


### PR DESCRIPTION
A new gauge metric named `bird_socket_query_success` holds the result of querying the bird socket for protocol status. If set to 1, the socket was queried successfully. If the query fails for any of the configured sockets (IPv4 / IPv6), the value of this metric will be 0.

Resolves #30 