### PR TITLE
Fix collecting for bfd sessions stucked in Init state

### DIFF
--- a/parser/bfd.go
+++ b/parser/bfd.go
@@ -14,7 +14,7 @@ var (
 )
 
 func init() {
-	bfdSessionRegex = regexp.MustCompile(`^([^\s]+)\s+([^\s]+)\s+(Up|Down)\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|[^\s]+)\s+([0-9\.]+)\s+([0-9\.]+)$`)
+	bfdSessionRegex = regexp.MustCompile(`^([^\s]+)\s+([^\s]+)\s+(Up|Down|Init)\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|[^\s]+)\s+([0-9\.]+)\s+([0-9\.]+)$`)
 }
 
 type bfdContext struct {

--- a/parser/bfd_test.go
+++ b/parser/bfd_test.go
@@ -17,11 +17,12 @@ func TestParseBFDSessions(t *testing.T) {
 bfd1:
 IP address                Interface  State      Since         Interval  Timeout
 192.168.64.9              enp0s2     Up         2022-01-27 09:00:00    0.100    1.000
-192.168.64.10             enp0s2     Down       2022-01-27 08:00:00    0.300    0.000`
+192.168.64.10             enp0s2     Down       2022-01-27 08:00:00    0.300    0.000
+192.168.64.12             enp0s2     Init       2022-01-27 08:00:00    0.300    5.000`
 
 	s := ParseBFDSessions("bfd1", []byte(data))
 
-	assert.Equal(t, 2, len(s), "session count")
+	assert.Equal(t, 3, len(s), "session count")
 
 	s1 := protocol.BFDSession{
 		ProtocolName: "bfd1",
@@ -41,5 +42,14 @@ IP address                Interface  State      Since         Interval  Timeout
 		Interval:     0.3,
 		Timeout:      0,
 	}
-	assert.Equal(t, []*protocol.BFDSession{&s1, &s2}, s, "sessions")
+	s3 := protocol.BFDSession{
+		ProtocolName: "bfd1",
+		IP:           "192.168.64.12",
+		Interface:    "enp0s2",
+		Up:           false,
+		Since:        7200,
+		Interval:     0.3,
+		Timeout:      5,
+	}
+	assert.Equal(t, []*protocol.BFDSession{&s1, &s2, &s3}, s, "sessions")
 }


### PR DESCRIPTION
If the BFD session state is set to Init, the metrics disappear. Thus, in the case of problems with stuck sessions in the init state, monitoring will not know about the problem.