### PR TITLE
Add support for sinceEpoch field in bfd session

### DIFF
--- a/parser/bfd.go
+++ b/parser/bfd.go
@@ -46,9 +46,7 @@ func parseBFDSessionLine(c *bfdContext) {
 		return
 	}
 	var since_epoch int64
-	if m[5] == "" {
-		since_epoch = 0
-	} else {
+	if m[5] != "" {
 		since_epoch = parseInt(m[5])
 	}
 

--- a/parser/bfd.go
+++ b/parser/bfd.go
@@ -14,7 +14,7 @@ var (
 )
 
 func init() {
-	bfdSessionRegex = regexp.MustCompile(`^([^\s]+)\s+([^\s]+)\s+(Up|Down|Init)\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|[^\s]+)\s+([0-9\.]+)\s+([0-9\.]+)$`)
+	bfdSessionRegex = regexp.MustCompile(`^([^\s]+)\s+([^\s]+)\s+(Up|Down|Init)\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}|[^\s]+)\s+(\d{1,})?\s+([0-9\.]+)\s+([0-9\.]+)$`)
 }
 
 type bfdContext struct {
@@ -45,14 +45,21 @@ func parseBFDSessionLine(c *bfdContext) {
 	if m == nil {
 		return
 	}
+	var since_epoch int64
+	if m[5] == "" {
+		since_epoch = 0
+	} else {
+		since_epoch = parseInt(m[5])
+	}
 
 	sess := protocol.BFDSession{
 		ProtocolName: c.protocol,
 		IP:           m[1],
 		Interface:    m[2],
 		Since:        parseUptime(m[4]),
-		Interval:     parseFloat(m[5]),
-		Timeout:      parseFloat(m[6]),
+		SinceEpoch:   since_epoch,
+		Interval:     parseFloat(m[6]),
+		Timeout:      parseFloat(m[7]),
 	}
 
 	if m[3] == "Up" {

--- a/parser/bfd_test.go
+++ b/parser/bfd_test.go
@@ -16,7 +16,7 @@ func TestParseBFDSessions(t *testing.T) {
 	data := `BIRD 2.0.7 ready.
 bfd1:
 IP address                Interface  State      Since         Interval  Timeout
-192.168.64.9              enp0s2     Up         2022-01-27 09:00:00    0.100    1.000
+192.168.64.9              enp0s2     Up         2022-01-27 09:00:00 1697620076    0.100    1.000
 192.168.64.10             enp0s2     Down       2022-01-27 08:00:00    0.300    0.000
 192.168.64.12             enp0s2     Init       2022-01-27 08:00:00    0.300    5.000`
 
@@ -30,6 +30,7 @@ IP address                Interface  State      Since         Interval  Timeout
 		Interface:    "enp0s2",
 		Up:           true,
 		Since:        3600,
+		SinceEpoch:   1697620076,
 		Interval:     0.1,
 		Timeout:      1,
 	}
@@ -39,6 +40,7 @@ IP address                Interface  State      Since         Interval  Timeout
 		Interface:    "enp0s2",
 		Up:           false,
 		Since:        7200,
+		SinceEpoch:   0,
 		Interval:     0.3,
 		Timeout:      0,
 	}
@@ -48,6 +50,7 @@ IP address                Interface  State      Since         Interval  Timeout
 		Interface:    "enp0s2",
 		Up:           false,
 		Since:        7200,
+		SinceEpoch:   0,
 		Interval:     0.3,
 		Timeout:      5,
 	}

--- a/protocol/bfd_session.go
+++ b/protocol/bfd_session.go
@@ -6,6 +6,7 @@ type BFDSession struct {
 	Interface    string
 	Up           bool
 	Since        int
+	SinceEpoch   int64
 	Interval     float64
 	Timeout      float64
 }


### PR DESCRIPTION
I noticed that there are no metrics for BFD sessions and found out that latest version of bird_exporter can not match the lines because Bird nows has another field with Unix epoch, see `1697620076` in below output
```
[xxx@node01 ~] (@coxz) $ sudo birdc show bfd session
BIRD 2.13.1 ready.
bfd1:
IP address                Interface  State      Since         Interval  Timeout
110.140.101.2               eth0       Down       2023-10-18 11:07:56 1697620076    1.000    0.000
110.140.101.1               eth0       Down       2023-10-18 11:07:56 1697620076    1.000    0.000
```

This my first Golang commit but I tried to fix it by adding support for that new field in a a way that it does not break the old output from Bird.

With this change I see BFD metrics but the uptime_seconds metric has value `0` and I don't know if it is due to my change or not; I don't have older versions of Bird to see if without the commit and with the older output that metric has a correct value. 
```
$ curl -s http://127.0.0.1:9324/metrics |grep ^bird_bfd_session_up
bird_bfd_session_up{interface="eth0",ip="110.140.101.1",name="bfd1"} 0
bird_bfd_session_up{interface="eth0",ip="110.410.101.2",name="bfd1"} 0
bird_bfd_session_uptime_seconds{interface="eth0",ip="110.140.101.1",name="bfd1"} 0
bird_bfd_session_uptime_seconds{interface="eth0",ip="110.140.101.2",name="bfd1"} 0

```
