### PR TITLE
Bump `cosign-installer` action and release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,9 +39,9 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        uses: sigstore/cosign-installer@v3.6.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v3.6.0'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
This should fix cosign installation in `build` job:
```
INFO: Downloading bootstrap version 'v1.11.1' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v1.11.1/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v1.13.1'
Error: Process completed with exit code 1.
```