### PR TITLE
feat(metrics): Remove BGP preferred metric

### DIFF
--- a/metrics/generic_exporter.go
+++ b/metrics/generic_exporter.go
@@ -30,7 +30,6 @@ func (m *GenericProtocolMetricExporter) Export(p *protocol.Protocol, ch chan<- p
 	var importCountDesc *prometheus.Desc
 	var exportCountDesc *prometheus.Desc
 	var filterCountDesc *prometheus.Desc
-	var preferredCountDesc *prometheus.Desc
 
 	upDesc := prometheus.NewDesc(m.prefix+"_up", "Protocol is up", append(labels, "state"), nil)
 
@@ -38,12 +37,10 @@ func (m *GenericProtocolMetricExporter) Export(p *protocol.Protocol, ch chan<- p
 		importCountDesc = prometheus.NewDesc(m.prefix+"_prefix_import_count", "Number of imported routes", labels, nil)
 		exportCountDesc = prometheus.NewDesc(m.prefix+"_prefix_export_count", "Number of exported routes", labels, nil)
 		filterCountDesc = prometheus.NewDesc(m.prefix+"_prefix_filter_count", "Number of filtered routes", labels, nil)
-		preferredCountDesc = prometheus.NewDesc(m.prefix+"_prefix_preferred_count", "Number of preferred routes", labels, nil)
 	} else {
 		importCountDesc = prometheus.NewDesc(m.prefix+"_prefix_count_import", "Number of imported routes", labels, nil)
 		exportCountDesc = prometheus.NewDesc(m.prefix+"_prefix_count_export", "Number of exported routes", labels, nil)
 		filterCountDesc = prometheus.NewDesc(m.prefix+"_prefix_count_filter", "Number of filtered routes", labels, nil)
-		preferredCountDesc = prometheus.NewDesc(m.prefix+"_prefix_count_preferred", "Number of preferred routes", labels, nil)
 	}
 
 	uptimeDesc := prometheus.NewDesc(m.prefix+"_uptime", "Uptime of the protocol in seconds", labels, nil)
@@ -73,7 +70,6 @@ func (m *GenericProtocolMetricExporter) Export(p *protocol.Protocol, ch chan<- p
 	ch <- prometheus.MustNewConstMetric(importCountDesc, prometheus.GaugeValue, float64(p.Imported), l...)
 	ch <- prometheus.MustNewConstMetric(exportCountDesc, prometheus.GaugeValue, float64(p.Exported), l...)
 	ch <- prometheus.MustNewConstMetric(filterCountDesc, prometheus.GaugeValue, float64(p.Filtered), l...)
-	ch <- prometheus.MustNewConstMetric(preferredCountDesc, prometheus.GaugeValue, float64(p.Preferred), l...)
 	ch <- prometheus.MustNewConstMetric(uptimeDesc, prometheus.GaugeValue, float64(p.Uptime), l...)
 	ch <- prometheus.MustNewConstMetric(updatesImportReceiveCountDesc, prometheus.GaugeValue, float64(p.ImportUpdates.Received), l...)
 	ch <- prometheus.MustNewConstMetric(updatesImportRejectCountDesc, prometheus.GaugeValue, float64(p.ImportUpdates.Rejected), l...)


### PR DESCRIPTION
Hello there
The `bird_protocol_prefix_preferred_count` Metric is Redundant (and Misleading); let me explain.

This metric does not actually count "preferred" (best-path) routes globally in BIRD. Instead, it counts:
> The number of routes from this peer that were accepted into BIRD’s decision process (and could potentially become preferred).

This metric misleadingly suggests it tracks the best paths, but it just counts valid routes from a peer. It's functionally useless because:

* It behaves almost identically to `bird_protocol_prefix_import_count` (both count routes accepted by import filters).
* Its name falsely implies it tracks "best-path" routes, which it does not.
* It adds no unique value while creating confusion.

---

One Example:

You have two BGP peers: _Peer A_ and _Peer B_.

_Peer A_ sends 100 routes:
* 90 pass filters → `bird_protocol_prefix_preferred_count{instance="Peer A"} = 90`
* Only 50 win best-path globally (due to shorter AS paths, etc.).

_Peer B_ sends 100 routes:
* 80 pass filters → `bird_protocol_prefix_preferred_count{instance="Peer B"} = 80`
* 50 wins best-path globally.

Here, `prefix_preferred_count` does not tell you how many routes 'won'—just how many were valid candidates, just like `bird_protocol_prefix_import_count`.