### PR TITLE
Add status command parser

### DIFF
--- a/client/bird_client.go
+++ b/client/bird_client.go
@@ -94,3 +94,13 @@ func (c *BirdClient) socketFor(ipVersion string) string {
 
 	return c.Options.BirdSocket
 }
+
+// StatusFromSocket retrieves status information from bird
+func (c *BirdClient) StatusFromSocket(socketPath string) (*parser.Status, error) {
+	b, err := birdsocket.Query(socketPath, "show status")
+	if err != nil {
+		return nil, err
+	}
+
+	return parser.ParseStatus(b), nil
+}

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func startServer() {
 func handleMetricsRequest(w http.ResponseWriter, r *http.Request) {
 	reg := prometheus.NewRegistry()
 	p := enabledProtocols()
-	c := NewMetricCollector(*newFormat, p, *descriptionLabels)
+	c := NewMetricCollector(*newFormat, p, *descriptionLabels, *birdSocket)
 	reg.MustRegister(c)
 
 	l := log.New()

--- a/metrics/status_exporter.go
+++ b/metrics/status_exporter.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"github.com/czerwonk/bird_exporter/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type StatusExporter struct {
+	client     *client.BirdClient
+	socketPath string
+
+	upDesc           *prometheus.Desc
+	infoDesc         *prometheus.Desc
+	lastRebootDesc   *prometheus.Desc
+	lastReconfigDesc *prometheus.Desc
+	serverTimeDesc   *prometheus.Desc
+}
+
+func NewStatusExporter(c *client.BirdClient, socketPath string) *StatusExporter {
+	return &StatusExporter{
+		client:     c,
+		socketPath: socketPath,
+
+		upDesc: prometheus.NewDesc(
+			"bird_daemon_up",
+			"Whether the BIRD daemon is up (1) or down (0)",
+			nil, nil,
+		),
+		infoDesc: prometheus.NewDesc(
+			"bird_daemon_info",
+			"Static information about BIRD",
+			[]string{"router_id", "version"}, nil,
+		),
+		lastRebootDesc: prometheus.NewDesc(
+			"bird_last_reboot_timestamp_seconds",
+			"Timestamp of the last BIRD reboot",
+			nil, nil,
+		),
+		lastReconfigDesc: prometheus.NewDesc(
+			"bird_last_reconfig_timestamp_seconds",
+			"Timestamp of the last BIRD reconfiguration",
+			nil, nil,
+		),
+		serverTimeDesc: prometheus.NewDesc(
+			"bird_server_time_timestamp_seconds",
+			"Server time reported by BIRD",
+			nil, nil,
+		),
+	}
+}
+
+func (e *StatusExporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- e.upDesc
+	ch <- e.infoDesc
+	ch <- e.lastRebootDesc
+	ch <- e.lastReconfigDesc
+	ch <- e.serverTimeDesc
+}
+
+func (e *StatusExporter) Collect(ch chan<- prometheus.Metric) {
+	s, err := e.client.StatusFromSocket(e.socketPath)
+	if err != nil || s == nil {
+		ch <- prometheus.MustNewConstMetric(e.upDesc, prometheus.GaugeValue, 0)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(e.upDesc, prometheus.GaugeValue, 1)
+	ch <- prometheus.MustNewConstMetric(e.infoDesc, prometheus.GaugeValue, 1, s.RouterID, s.Version)
+
+	if !s.LastReboot.IsZero() {
+		ch <- prometheus.MustNewConstMetric(e.lastRebootDesc, prometheus.GaugeValue, float64(s.LastReboot.Unix()))
+	}
+	if !s.LastReconfig.IsZero() {
+		ch <- prometheus.MustNewConstMetric(e.lastReconfigDesc, prometheus.GaugeValue, float64(s.LastReconfig.Unix()))
+	}
+	if !s.ServerTime.IsZero() {
+		ch <- prometheus.MustNewConstMetric(e.serverTimeDesc, prometheus.GaugeValue, float64(s.ServerTime.Unix()))
+	}
+}

--- a/parser/status.go
+++ b/parser/status.go
@@ -1,0 +1,58 @@
+package parser
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+type Status struct {
+	Version      string
+	RouterID     string
+	ServerTime   time.Time
+	LastReboot   time.Time
+	LastReconfig time.Time
+	DaemonUp     bool
+}
+
+var (
+	reVersion    = regexp.MustCompile(`BIRD (\S+)`)
+	reRouterID   = regexp.MustCompile(`Router ID is (\S+)`)
+	reServerTime = regexp.MustCompile(`Current server time is (.+)`)
+	reReboot     = regexp.MustCompile(`Last reboot on (.+)`)
+	reReconfig   = regexp.MustCompile(`Last reconfiguration on (.+)`)
+	reDaemon     = regexp.MustCompile(`Daemon is (.+)`)
+	timeLayout   = "2006-01-02 15:04:05.000" // ref: https://pkg.go.dev/time#Parse
+)
+
+func ParseStatus(b []byte) *Status {
+	s := &Status{}
+	out := string(b)
+
+	if m := reVersion.FindStringSubmatch(out); len(m) > 1 {
+		s.Version = m[1]
+	}
+	if m := reRouterID.FindStringSubmatch(out); len(m) > 1 {
+		s.RouterID = m[1]
+	}
+	if m := reServerTime.FindStringSubmatch(out); len(m) > 1 {
+		if t, err := time.Parse(timeLayout, strings.TrimSpace(m[1])); err == nil {
+			s.ServerTime = t
+		}
+	}
+	if m := reReboot.FindStringSubmatch(out); len(m) > 1 {
+		if t, err := time.Parse(timeLayout, strings.TrimSpace(m[1])); err == nil {
+			s.LastReboot = t
+		}
+	}
+	if m := reReconfig.FindStringSubmatch(out); len(m) > 1 {
+		if t, err := time.Parse(timeLayout, strings.TrimSpace(m[1])); err == nil {
+			s.LastReconfig = t
+		}
+	}
+	if m := reDaemon.FindStringSubmatch(out); len(m) > 1 {
+		s.DaemonUp = strings.Contains(m[1], "up")
+	}
+
+	return s
+}

--- a/parser/status_test.go
+++ b/parser/status_test.go
@@ -1,0 +1,94 @@
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseStatus(t *testing.T) {
+	sample := `
+BIRD 2.17.1 ready.
+BIRD 2.17.1
+Router ID is 10.72.0.164
+Hostname is store-blob-pp014
+Current server time is 2025-08-21 10:27:57.219
+Last reboot on 2025-07-31 14:23:03.232
+Last reconfiguration on 2025-08-07 09:53:19.531
+Daemon is up and running
+`
+
+	s := ParseStatus([]byte(sample))
+
+	if s.Version != "2.17.1" {
+		t.Errorf("expected Version=2.17.1, got %q", s.Version)
+	}
+	if s.RouterID != "10.72.0.164" {
+		t.Errorf("expected RouterID=10.72.0.164, got %q", s.RouterID)
+	}
+
+	expectedServerTime := time.Date(2025, 8, 21, 10, 27, 57, 219000000, time.UTC)
+	if !s.ServerTime.Equal(expectedServerTime) {
+		t.Errorf("expected ServerTime=%v, got %v", expectedServerTime, s.ServerTime)
+	}
+
+	expectedLastReboot := time.Date(2025, 7, 31, 14, 23, 3, 232000000, time.UTC)
+	if !s.LastReboot.Equal(expectedLastReboot) {
+		t.Errorf("expected LastReboot=%v, got %v", expectedLastReboot, s.LastReboot)
+	}
+
+	expectedLastReconfig := time.Date(2025, 8, 7, 9, 53, 19, 531000000, time.UTC)
+	if !s.LastReconfig.Equal(expectedLastReconfig) {
+		t.Errorf("expected LastReconfig=%v, got %v", expectedLastReconfig, s.LastReconfig)
+	}
+
+	if !s.DaemonUp {
+		t.Errorf("expected DaemonUp=true, got false")
+	}
+}
+
+func TestParseStatusMissingFields(t *testing.T) {
+	sample := `
+BIRD 2.17.1
+Daemon is down
+`
+
+	s := ParseStatus([]byte(sample))
+
+	if s.Version != "2.17.1" {
+		t.Errorf("expected Version=2.17.1, got %q", s.Version)
+	}
+	if s.DaemonUp {
+		t.Errorf("expected DaemonUp=false, got true")
+	}
+
+	// Other fields should be zero-values
+	if !s.ServerTime.IsZero() {
+		t.Errorf("expected ServerTime zero, got %v", s.ServerTime)
+	}
+	if !s.LastReboot.IsZero() {
+		t.Errorf("expected LastReboot zero, got %v", s.LastReboot)
+	}
+	if !s.LastReconfig.IsZero() {
+		t.Errorf("expected LastReconfig zero, got %v", s.LastReconfig)
+	}
+	if s.RouterID != "" {
+		t.Errorf("expected RouterID empty, got %q", s.RouterID)
+	}
+}
+
+func TestParseStatusMalformedTime(t *testing.T) {
+	sample := `
+BIRD 2.17.1
+Current server time is not-a-time
+Daemon is up
+`
+
+	s := ParseStatus([]byte(sample))
+
+	if !s.DaemonUp {
+		t.Errorf("expected DaemonUp=true, got false")
+	}
+	if !s.ServerTime.IsZero() {
+		t.Errorf("expected ServerTime zero due to parse error, got %v", s.ServerTime)
+	}
+}


### PR DESCRIPTION
This will bring 5 new metrics exported from `show status`:
 - bird_daemon_up
 - bird_daemon_info
 - bird_last_reboot_timestamp_seconds
 - bird_last_reconfig_timestamp_seconds
 - bird_server_time_timestamp_seconds

This is very useful when playing with different versions of BIRD and update configuration on runtime.

```
bird> show status
BIRD 2.17.1
Router ID is 127.0.0.1
Hostname is dummy-host
Current server time is 2025-09-30 12:46:38.895
Last reboot on 2025-09-30 11:40:36.628
Last reconfiguration on 2025-09-30 11:40:36.628
Daemon is up and running
```

```
# HELP bird_daemon_info Static information about BIRD
# TYPE bird_daemon_info gauge
bird_daemon_info{router_id="127.0.0.1",version="2.17.1"} 1
# HELP bird_daemon_up Whether the BIRD daemon is up (1) or down (0)
# TYPE bird_daemon_up gauge
bird_daemon_up 1
# HELP bird_last_reboot_timestamp_seconds Timestamp of the last BIRD reboot
# TYPE bird_last_reboot_timestamp_seconds gauge
bird_last_reboot_timestamp_seconds 1.759232436e+09
# HELP bird_last_reconfig_timestamp_seconds Timestamp of the last BIRD reconfiguration
# TYPE bird_last_reconfig_timestamp_seconds gauge
bird_last_reconfig_timestamp_seconds 1.759232436e+09
# HELP bird_server_time_timestamp_seconds Server time reported by BIRD
# TYPE bird_server_time_timestamp_seconds gauge
bird_server_time_timestamp_seconds 1.759236496e+09
```