### PR TITLE
Avoid negative uptime in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/bird_exporter
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/bird_exporter
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates bash
+RUN apk --no-cache add ca-certificates bash tzdata
 WORKDIR /app
 COPY --from=builder /go/bin/bird_exporter .
 EXPOSE 9324


### PR DESCRIPTION
There was PR to use localtime while parsing time #43 and #39
But exporter running in container require same timezone inside.
So, this PR adding tzdata package to image.

Note, to use this feature you have to run container with TZ environment variable. Set it to your preferred timezone (same as timezone used by bird daemon).