### PR TITLE
feat(protocol-stats): add support for Bird 3.0 route change stats format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Since version 1.1 bird_exporter can be used with bird 2.0+ using the `-bird.v2` 
 When using this parameter bird_exporter queries the same bird socket for IPv4 and IPv6.
 In this mode the IP protocol is determined by the channel information and parameters `-bird.ipv4`, `-bird.ipv6` and `-bird.socket6` are ignored.
 
+Bird 3.0 adds two extra columns (RX limit, limit) to route change stats. The exporter detects this format automatically.
+
 ## Metric formats
 
 In version 1.0 a new metric format was introduced.

--- a/metrics/generic_exporter.go
+++ b/metrics/generic_exporter.go
@@ -95,4 +95,24 @@ func (m *GenericProtocolMetricExporter) Export(p *protocol.Protocol, ch chan<- p
 	ch <- prometheus.MustNewConstMetric(withdrawsExportFilterCountDesc, prometheus.GaugeValue, float64(p.ExportWithdraws.Filtered), l...)
 	ch <- prometheus.MustNewConstMetric(withdrawsExportAcceptCountDesc, prometheus.GaugeValue, float64(p.ExportWithdraws.Accepted), l...)
 	ch <- prometheus.MustNewConstMetric(withdrawsExportIgnoreCountDesc, prometheus.GaugeValue, float64(p.ExportWithdraws.Ignored), l...)
+	
+	if p.RouteChangeFormatV3 {
+		updatesImportRxLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_update_import_rx_limit_count", "Number of incoming updates reaching RX limit", labels, nil)
+		updatesImportLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_update_import_limit_count", "Number of incoming updates reaching limit", labels, nil)
+		updatesExportRxLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_update_export_rx_limit_count", "Number of outgoing updates reaching RX limit", labels, nil)
+		updatesExportLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_update_export_limit_count", "Number of outgoing updates reaching limit", labels, nil)
+		withdrawsImportRxLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_withdraw_import_rx_limit_count", "Number of incoming withdraws reaching RX limit", labels, nil)
+		withdrawsImportLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_withdraw_import_limit_count", "Number of incoming withdraws reaching limit", labels, nil)
+		withdrawsExportRxLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_withdraw_export_rx_limit_count", "Number of outgoing withdraws reaching RX limit", labels, nil)
+		withdrawsExportLimitCountDesc := prometheus.NewDesc(m.prefix+"_changes_withdraw_export_limit_count", "Number of outgoing withdraws reaching limit", labels, nil)
+
+		ch <- prometheus.MustNewConstMetric(updatesImportRxLimitCountDesc, prometheus.GaugeValue, float64(p.ImportUpdates.RxLimit), l...)
+		ch <- prometheus.MustNewConstMetric(updatesImportLimitCountDesc, prometheus.GaugeValue, float64(p.ImportUpdates.Limit), l...)
+		ch <- prometheus.MustNewConstMetric(updatesExportRxLimitCountDesc, prometheus.GaugeValue, float64(p.ExportUpdates.RxLimit), l...)
+		ch <- prometheus.MustNewConstMetric(updatesExportLimitCountDesc, prometheus.GaugeValue, float64(p.ExportUpdates.Limit), l...)
+		ch <- prometheus.MustNewConstMetric(withdrawsImportRxLimitCountDesc, prometheus.GaugeValue, float64(p.ImportWithdraws.RxLimit), l...)
+		ch <- prometheus.MustNewConstMetric(withdrawsImportLimitCountDesc, prometheus.GaugeValue, float64(p.ImportWithdraws.Limit), l...)
+		ch <- prometheus.MustNewConstMetric(withdrawsExportRxLimitCountDesc, prometheus.GaugeValue, float64(p.ExportWithdraws.RxLimit), l...)
+		ch <- prometheus.MustNewConstMetric(withdrawsExportLimitCountDesc, prometheus.GaugeValue, float64(p.ExportWithdraws.Limit), l...)
+	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,13 +11,14 @@ import (
 )
 
 var (
-	protocolRegex    *regexp.Regexp
-	descriptionRegex *regexp.Regexp
-	routeRegex       *regexp.Regexp
-	uptimeRegex      *regexp.Regexp
-	routeChangeRegex *regexp.Regexp
-	filterRegex      *regexp.Regexp
-	channelRegex     *regexp.Regexp
+	protocolRegex    		*regexp.Regexp
+	descriptionRegex 		*regexp.Regexp
+	routeRegex       		*regexp.Regexp
+	uptimeRegex      		*regexp.Regexp
+	routeChangeRegexLegacy 	*regexp.Regexp
+	routeChangeRegexV3     	*regexp.Regexp
+	filterRegex      		*regexp.Regexp
+	channelRegex     		*regexp.Regexp
 )
 
 type context struct {
@@ -33,7 +34,8 @@ func init() {
 	descriptionRegex = regexp.MustCompile(`Description:\s+(.*)`)
 	routeRegex = regexp.MustCompile(`^\s+Routes:\s+(\d+) imported, (?:(\d+) filtered, )?(\d+) exported(?:, (\d+) preferred)?`)
 	uptimeRegex = regexp.MustCompile(`^(?:((\d+):(\d{2}):(\d{2}))|(\d+)|(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:|\.\d+)))$`)
-	routeChangeRegex = regexp.MustCompile(`(Import|Export) (updates|withdraws):\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s*`)
+	routeChangeRegexLegacy = regexp.MustCompile(`(Import|Export) (updates|withdraws):\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s*`)
+	routeChangeRegexV3 = regexp.MustCompile(`(Import|Export) (updates|withdraws):\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)\s+(\d+|---)`)
 	filterRegex = regexp.MustCompile(`(Input|Output) filter:\s+(.*)`)
 	channelRegex = regexp.MustCompile(`Channel ipv(4|6)`)
 }
@@ -172,11 +174,12 @@ func parseLineForChannel(c *context) {
 		c.current.IPVersion = channel[1]
 	} else {
 		c.current = &protocol.Protocol{
-			Name:      c.current.Name,
-			Proto:     c.current.Proto,
-			Up:        c.current.Up,
-			Uptime:    c.current.Uptime,
-			IPVersion: channel[1],
+			Name:               	c.current.Name,
+			Proto:              	c.current.Proto,
+			Up:                 	c.current.Up,
+			Uptime:             	c.current.Uptime,
+			IPVersion:          	channel[1],
+			RouteChangeFormatV3: 	c.current.RouteChangeFormatV3,
 		}
 		c.protocols = append(c.protocols, c.current)
 	}
@@ -213,19 +216,39 @@ func parseLineForRouteChanges(c *context) {
 		return
 	}
 
-	match := routeChangeRegex.FindStringSubmatch(c.line)
-	if match == nil {
+	match := routeChangeRegexV3.FindStringSubmatch(c.line)
+	if match != nil {
+		x := getRouteChangeCount(match, c.current)
+		x.Received = parseRouteChangeValue(match[3])
+		x.Rejected = parseRouteChangeValue(match[4])
+		x.Filtered = parseRouteChangeValue(match[5])
+		x.Ignored = parseRouteChangeValue(match[6])
+		x.RxLimit = parseRouteChangeValue(match[7])
+		x.Limit = parseRouteChangeValue(match[8])
+		x.Accepted = parseRouteChangeValue(match[9])
+
+		c.current.RouteChangeFormatV3 = true
+		c.handled = true
 		return
 	}
 
-	x := getRouteChangeCount(match, c.current)
-	x.Received = parseRouteChangeValue(match[3])
-	x.Rejected = parseRouteChangeValue(match[4])
-	x.Filtered = parseRouteChangeValue(match[5])
-	x.Ignored = parseRouteChangeValue(match[6])
-	x.Accepted = parseRouteChangeValue(match[7])
+	match = routeChangeRegexLegacy.FindStringSubmatch(c.line)
+	if match != nil {
+		x := getRouteChangeCount(match, c.current)
+		x.Received = parseRouteChangeValue(match[3])
+		x.Rejected = parseRouteChangeValue(match[4])
+		x.Filtered = parseRouteChangeValue(match[5])
+		x.Ignored = parseRouteChangeValue(match[6])
+		x.RxLimit = 0
+		x.Limit = 0
+		x.Accepted = parseRouteChangeValue(match[7])
 
-	c.handled = true
+		c.current.RouteChangeFormatV3 = false
+		c.handled = true
+		return
+	}
+
+	return
 }
 
 func getRouteChangeCount(values []string, p *protocol.Protocol) *protocol.RouteChangeCount {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -112,21 +112,70 @@ func TestUpdateAndWithdrawCounts(t *testing.T) {
 	assert.Int64Equal("import updates rejected", 2, x.ImportUpdates.Rejected, t)
 	assert.Int64Equal("import updates filtered", 3, x.ImportUpdates.Filtered, t)
 	assert.Int64Equal("import updates ignored", 4, x.ImportUpdates.Ignored, t)
+	assert.Int64Equal("import updates rx limit", 0, x.ImportUpdates.RxLimit, t)
+	assert.Int64Equal("import updates limit", 0, x.ImportUpdates.Limit, t)
 	assert.Int64Equal("import updates accepted", 5, x.ImportUpdates.Accepted, t)
 	assert.Int64Equal("import withdraws received", 6, x.ImportWithdraws.Received, t)
 	assert.Int64Equal("import withdraws rejected", 7, x.ImportWithdraws.Rejected, t)
 	assert.Int64Equal("import withdraws filtered", 8, x.ImportWithdraws.Filtered, t)
 	assert.Int64Equal("import withdraws ignored", 9, x.ImportWithdraws.Ignored, t)
+	assert.Int64Equal("import withdraws rx limit", 0, x.ImportWithdraws.RxLimit, t)
+	assert.Int64Equal("import withdraws limit", 0, x.ImportWithdraws.Limit, t)
 	assert.Int64Equal("import withdraws accepted", 10, x.ImportWithdraws.Accepted, t)
 	assert.Int64Equal("export updates received", 11, x.ExportUpdates.Received, t)
 	assert.Int64Equal("export updates rejected", 12, x.ExportUpdates.Rejected, t)
 	assert.Int64Equal("export updates filtered", 13, x.ExportUpdates.Filtered, t)
 	assert.Int64Equal("export updates ignored", 14, x.ExportUpdates.Ignored, t)
+	assert.Int64Equal("export updates rx limit", 0, x.ExportUpdates.RxLimit, t)
+	assert.Int64Equal("export updates limit", 0, x.ExportUpdates.Limit, t)
 	assert.Int64Equal("export updates accepted", 15, x.ExportUpdates.Accepted, t)
 	assert.Int64Equal("export withdraws received", 16, x.ExportWithdraws.Received, t)
 	assert.Int64Equal("export withdraws rejected", 17, x.ExportWithdraws.Rejected, t)
 	assert.Int64Equal("export withdraws filtered", 18, x.ExportWithdraws.Filtered, t)
 	assert.Int64Equal("export withdraws ignored", 19, x.ExportWithdraws.Ignored, t)
+	assert.Int64Equal("export withdraws rx limit", 0, x.ExportWithdraws.RxLimit, t)
+	assert.Int64Equal("export withdraws limit", 0, x.ExportWithdraws.Limit, t)
+	assert.Int64Equal("export withdraws accepted", 0, x.ExportWithdraws.Accepted, t)
+}
+
+func TestUpdateAndWithdrawCountsBird3(t *testing.T) {
+	data := "foo    BGP      master   up     00:01:00  Established\ntest\n" +
+		"  Routes:         12 imported, 1 filtered, 34 exported, 100 preferred\n" +
+		"  Route change stats:     received   rejected   filtered    ignored   RX limit      limit   accepted\n" +
+		"    Import updates:              1          2          3          4          9         10          5\n" +
+		"    Import withdraws:            6          7          8          9         10         11         12\n" +
+		"    Export updates:             11         12         13         14         15         16         17\n" +
+		"    Export withdraws:           16         17         18         19         20         21        ---"
+	p := ParseProtocols([]byte(data), "4")
+	x := p[0]
+
+	assert.Int64Equal("import updates received", 1, x.ImportUpdates.Received, t)
+	assert.Int64Equal("import updates rejected", 2, x.ImportUpdates.Rejected, t)
+	assert.Int64Equal("import updates filtered", 3, x.ImportUpdates.Filtered, t)
+	assert.Int64Equal("import updates ignored", 4, x.ImportUpdates.Ignored, t)
+	assert.Int64Equal("import updates rx limit", 9, x.ImportUpdates.RxLimit, t)
+	assert.Int64Equal("import updates limit", 10, x.ImportUpdates.Limit, t)
+	assert.Int64Equal("import updates accepted", 5, x.ImportUpdates.Accepted, t)
+	assert.Int64Equal("import withdraws received", 6, x.ImportWithdraws.Received, t)
+	assert.Int64Equal("import withdraws rejected", 7, x.ImportWithdraws.Rejected, t)
+	assert.Int64Equal("import withdraws filtered", 8, x.ImportWithdraws.Filtered, t)
+	assert.Int64Equal("import withdraws ignored", 9, x.ImportWithdraws.Ignored, t)
+	assert.Int64Equal("import withdraws rx limit", 10, x.ImportWithdraws.RxLimit, t)
+	assert.Int64Equal("import withdraws limit", 11, x.ImportWithdraws.Limit, t)
+	assert.Int64Equal("import withdraws accepted", 12, x.ImportWithdraws.Accepted, t)
+	assert.Int64Equal("export updates received", 11, x.ExportUpdates.Received, t)
+	assert.Int64Equal("export updates rejected", 12, x.ExportUpdates.Rejected, t)
+	assert.Int64Equal("export updates filtered", 13, x.ExportUpdates.Filtered, t)
+	assert.Int64Equal("export updates ignored", 14, x.ExportUpdates.Ignored, t)
+	assert.Int64Equal("export updates rx limit", 15, x.ExportUpdates.RxLimit, t)
+	assert.Int64Equal("export updates limit", 16, x.ExportUpdates.Limit, t)
+	assert.Int64Equal("export updates accepted", 17, x.ExportUpdates.Accepted, t)
+	assert.Int64Equal("export withdraws received", 16, x.ExportWithdraws.Received, t)
+	assert.Int64Equal("export withdraws rejected", 17, x.ExportWithdraws.Rejected, t)
+	assert.Int64Equal("export withdraws filtered", 18, x.ExportWithdraws.Filtered, t)
+	assert.Int64Equal("export withdraws ignored", 19, x.ExportWithdraws.Ignored, t)
+	assert.Int64Equal("export withdraws rx limit", 20, x.ExportWithdraws.RxLimit, t)
+	assert.Int64Equal("export withdraws limit", 21, x.ExportWithdraws.Limit, t)
 	assert.Int64Equal("export withdraws accepted", 0, x.ExportWithdraws.Accepted, t)
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -21,6 +21,7 @@ type Protocol struct {
 	ImportFilter    string
 	ExportFilter    string
 	Proto           Proto
+	RouteChangeFormatV3 bool
 	Up              int
 	State           string
 	Imported        int64
@@ -39,6 +40,8 @@ type RouteChangeCount struct {
 	Rejected int64
 	Filtered int64
 	Ignored  int64
+	RxLimit  int64
+	Limit    int64
 	Accepted int64
 }
 


### PR DESCRIPTION
This PR adds adaptive support for the Bird 3.0 route change stats format, where extra columns are added, such as RX limit and limit.

Fix #133 