### PR TITLE
feat(docker): add cross-compilation support for docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM golang as builder
+FROM --platform=$BUILDPLATFORM golang AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 ADD . /go/bird_exporter/
 WORKDIR /go/bird_exporter
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/bin/bird_exporter
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+	GOARM=${TARGETVARIANT#v} \
+	go build -a -installsuffix cgo -o /go/bin/bird_exporter
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates bash tzdata


### PR DESCRIPTION
This PR adds the capability to cross-compile the image for multiple platforms using `buildx` with the `Dockerfile`.

To build with CLI:
```
docker buildx build \
  --builder <builder_name> \
  --platform linux/amd64,linux/arm64,linux/arm/v7 \
  --push -t <tag> \
  .
```

Or, with Github Actions, add:
```
with:
     platforms: linux/amd64,linux/arm64,linux/arm/v7
```

Related to: #103