### PR TITLE
build: harden HTTP and container delivery

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+**
+!go.mod
+!go.sum
+!*.go
+!client/
+!client/*.go
+!metrics/
+!metrics/*.go
+!parser/
+!parser/*.go
+!protocol/
+!protocol/*.go
+*_test.go
+**/*_test.go

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,90 +1,100 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
     branches: ["main"]
-    # Publish semver tags as releases.
     tags: ["v*.*.*"]
   pull_request:
     branches: ["main"]
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+
+  publish:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.8.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          cosign-release: "v2.4.3"
+          persist-credentials: false
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build and push container image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          cache-from: type=gha,scope=bird-exporter-publish
+          cache-to: type=gha,mode=max,scope=bird-exporter-publish
+          provenance: mode=max
+          sbom: true
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+      - name: Sign published image digests
         env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes {}@${{ steps.build-and-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: printf '%s\n' "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -16,9 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -26,9 +27,9 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          version: "latest"
+          version: v3.21.3
 
       - name: Package Helm chart
         run: |
@@ -36,7 +37,7 @@ jobs:
           helm package charts/bird-exporter -d .charts-tmp
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,34 @@
+name: Release
+
 on:
   push:
     tags:
       - "v*.*.*"
 
-name: Release
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
+          cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          args: release
+          version: v2.17.1
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: Test
+
 on:
   push:
     branches:
@@ -6,26 +8,59 @@ on:
     branches:
       - main
 
-name: Test
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        go-version: ["1.26.x"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - name: Install Go
-        if: success()
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify modules
+        run: go mod verify
 
       - name: Build
-        run: go build
+        run: go build ./...
 
       - name: Run tests
         run: go test ./... -v -covermode=count
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Race detector
+        run: go test -race ./...
+
+      - name: Vulnerability scan
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+
+      - name: Security static analysis
+        run: go run github.com/securego/gosec/v2/cmd/gosec@v2.28.0 ./...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,20 +1,30 @@
+version: 2
+
 dist: artifacts
+
 before:
-   hooks:
-     - go mod download
+  hooks:
+    - go mod download
+
 builds:
-  - env:
-    - CGO_ENABLED=0
+  - binary: bird_exporter
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
     goos:
-    - linux
-    - darwin
-    - freebsd
+      - linux
+      - darwin
+      - freebsd
     goarch:
-    - amd64
-    - arm
-    - arm64
+      - amd64
+      - arm
+      - arm64
     ignore:
-    - goos: freebsd
-      goarch: arm64
-    ldflags: -s -w -X main.version={{.Version}}
-    binary: bird_exporter 
+      - goos: freebsd
+        goarch: arm64
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+checksum:
+  name_template: checksums.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,35 @@
-FROM --platform=$BUILDPLATFORM golang AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
+
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
-ADD . /go/bird_exporter/
-WORKDIR /go/bird_exporter
+ARG VERSION=dev
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY *.go ./
+COPY client ./client
+COPY metrics ./metrics
+COPY parser ./parser
+COPY protocol ./protocol
+
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
 	GOARM=${TARGETVARIANT#v} \
-	go build -a -installsuffix cgo -o /go/bin/bird_exporter
+	go build -trimpath \
+	-ldflags="-s -w -X main.version=${VERSION}" \
+	-o /out/bird_exporter .
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates bash tzdata
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+
+RUN apk --no-cache add ca-certificates tzdata \
+	&& addgroup -S -g 1000 bird-exporter \
+	&& adduser -S -D -H -u 1000 -G bird-exporter bird-exporter
+
 WORKDIR /app
-COPY --from=builder /go/bin/bird_exporter .
-EXPOSE 9324
+COPY --from=builder /out/bird_exporter /app/bird_exporter
 
+USER 1000:1000
+EXPOSE 9324
 ENTRYPOINT ["/app/bird_exporter"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ In version 0.7.1 the default port changed to 9324 since port 9200 is the default
 
 In version 0.8 communication to bird changed to sockets. The default socket path is `/var/run/bird.ctl` (for bird) and `/var/run/bird6.ctl` (for bird6). In case you are using different paths in your installation, the socket path can be specified by usind the `-bird.socket` (for bird) and `-bird.socket6` (for bird6) flag.
 
+The BIRD control socket is a privileged command channel. Prefer a dedicated
+restricted BIRD CLI socket where the BIRD version supports it, and grant the
+exporter process access only to that socket.
+
+The standalone binary listens on all interfaces for compatibility. Bind to
+loopback, apply a network allowlist, or put the endpoint behind an
+authenticating TLS reverse proxy when the metrics network is not trusted.
+
 ## Install
 
 ```
@@ -89,11 +97,22 @@ Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "bird-exporter" chart repository
 Update Complete. ⎈Happy Helming!⎈
 
-$ helm install bird-exporter bird-exporter/bird_exporter
+$ helm install bird-exporter bird-exporter/bird-exporter
 NAME: bird-exporter
 ...
 
 ```
+
+The chart uses `ghcr.io/czerwonk/bird_exporter` and runs as UID/GID 1000 with
+all capabilities dropped, a read-only root filesystem, the RuntimeDefault
+seccomp profile, and no Kubernetes service-account token. Set `fsGroup` to the
+numeric group that can access the selected BIRD socket. A read-only mount does
+not make the BIRD command protocol read-only.
+
+The container image also runs as UID/GID 1000 outside Kubernetes. Add only the
+host socket group with Docker's `--group-add` option instead of running the
+container as root. Set `TZ` to the BIRD host timezone when BIRD emits local
+timestamps without a timezone.
 
 ## Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are developed against the latest release and the default branch.
+Users should upgrade to the latest available release before reporting an issue.
+
+## Reporting a vulnerability
+
+Do not disclose exploitable details in a public issue. Use **Report a
+vulnerability** on the repository's Security tab to send a private report. If
+private vulnerability reporting is unavailable, contact the maintainer through
+their GitHub profile and request a private channel without including the
+vulnerability details.
+
+Include the affected version, deployment model, reproduction conditions,
+impact, and any tested mitigation. Reports concerning BIRD control-socket
+framing should also identify the BIRD version and approximate reply size.

--- a/charts/bird-exporter/Chart.yaml
+++ b/charts/bird-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bird-exporter
 description: Exporter for bird-exporter
 type: application
-version: 0.1.3
-appVersion: "1.4.5"
+version: 0.1.4
+appVersion: "v1.5.0"
 sources:
-  - https://github.com/czerwonk/bird-exporter
+  - https://github.com/czerwonk/bird_exporter

--- a/charts/bird-exporter/templates/daemonset.yaml
+++ b/charts/bird-exporter/templates/daemonset.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         {{- include "bird-exporter.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -57,3 +58,4 @@ spec:
       - name: bird-socket
         hostPath:
           path: {{ .Values.exporter.birdSocketPath }}
+          type: Directory

--- a/charts/bird-exporter/values.yaml
+++ b/charts/bird-exporter/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: czerwonk/bird_exporter
+  repository: ghcr.io/czerwonk/bird_exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -35,8 +35,12 @@ podAnnotations: {}
 
 podSecurityContext:
   fsGroup: 2000
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
     - ALL

--- a/examples/kubernetes/daemonset.yaml
+++ b/examples/kubernetes/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: bird-exporter
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: bird-exporter
 spec:
+  selector:
+    matchLabels:
+      app: bird-exporter
   updateStrategy:
     type: RollingUpdate
   template:
@@ -13,28 +16,55 @@ spec:
       labels:
         app: bird-exporter
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
       containers:
-      - name: bird-exporter
-        image: bird_exporter:latest
-        args: ["-format.new=true", "-bird.socket=/var/run/bird/bird.ctl"]
-        resources:
-          limits:
-            cpu: 100m
-            memory: 32Mi
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /var/run/bird/
-          name: bird-socket
-          readOnly: true
-        ports:
-          - containerPort: 9324
-            name: metrics
+        - name: bird-exporter
+          image: ghcr.io/czerwonk/bird_exporter:v1.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -format.new=true
+            - -bird.socket=/var/run/bird/bird.ctl
+            - -bird.socket6=/var/run/bird/bird6.ctl
+            - -web.scrape-timeout=5s
+            - -web.max-concurrent-scrapes=1
+            - -bird.max-response-bytes=4194304
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          ports:
+            - containerPort: 9324
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/run/bird
+              name: bird-socket
+              readOnly: true
       volumes:
-      - name: bird-socket
-        hostPath:
-          path: /var/run/bird/
+        - name: bird-socket
+          hostPath:
+            path: /var/run/bird
+            type: Directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/czerwonk/bird_exporter
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/czerwonk/bird_socket v1.0.1

--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/czerwonk/bird_exporter/protocol"
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,7 +14,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const version string = "1.5.0"
+var version = "1.5.0"
+
+const (
+	serverReadHeaderTimeout = 5 * time.Second
+	serverReadTimeout       = 10 * time.Second
+	serverWriteTimeout      = 30 * time.Second
+	serverIdleTimeout       = 60 * time.Second
+	serverMaxHeaderBytes    = 1 << 20
+)
 
 var (
 	showVersion      = flag.Bool("version", false, "Print version information.")
@@ -73,26 +83,65 @@ func startServer() {
 		log.Info("INFO: You are using the old metric format. Please consider using the new (more convenient one) by setting -format.new=true.")
 	}
 
-	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte(`<html>
-			<head><title>Bird Routing Daemon Exporter (Version ` + version + `)</title></head>
-			<body>
-			<h1>Bird Routing Daemon Exporter</h1>
-			<p><a href="` + *metricsPath + `">Metrics</a></p>
-			<h2>More information:</h2>
-			<p><a href="https://github.com/czerwonk/bird_exporter">github.com/czerwonk/bird_exporter</a></p>
-			</body>
-			</html>`))
-	})
-	http.HandleFunc(*metricsPath, handleMetricsRequest)
+	mux := newHTTPMux(*metricsPath, handleMetricsRequest)
+	server := newHTTPServer(*listenAddress, mux)
 
 	log.Infof("Listening for %s on %s (TLS: %v)", *metricsPath, *listenAddress, *tlsEnabled)
 	if *tlsEnabled {
-		log.Fatal(http.ListenAndServeTLS(*listenAddress, *tlsCertChainPath, *tlsKeyPath, nil))
+		log.Fatal(server.ListenAndServeTLS(*tlsCertChainPath, *tlsKeyPath))
 		return
 	}
 
-	log.Fatal(http.ListenAndServe(*listenAddress, nil))
+	log.Fatal(server.ListenAndServe())
+}
+
+func newHTTPMux(metricsPath string, metricsHandler http.HandlerFunc) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/" {
+			http.NotFound(w, request)
+			return
+		}
+		if request.Method != http.MethodGet && request.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		_, err := io.WriteString(w, `<html>
+			<head><title>Bird Routing Daemon Exporter (Version `+version+`)</title></head>
+			<body>
+			<h1>Bird Routing Daemon Exporter</h1>
+			<p><a href="`+metricsPath+`">Metrics</a></p>
+			<h2>More information:</h2>
+			<p><a href="https://github.com/czerwonk/bird_exporter">github.com/czerwonk/bird_exporter</a></p>
+			</body>
+			</html>`)
+		if err != nil {
+			log.Warnf("Could not write landing page: %v", err)
+		}
+	})
+	mux.HandleFunc(metricsPath, func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		metricsHandler(w, request)
+	})
+	return mux
+}
+
+func newHTTPServer(address string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              address,
+		Handler:           handler,
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		ReadTimeout:       serverReadTimeout,
+		WriteTimeout:      serverWriteTimeout,
+		IdleTimeout:       serverIdleTimeout,
+		MaxHeaderBytes:    serverMaxHeaderBytes,
+	}
 }
 
 func handleMetricsRequest(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/czerwonk/bird_exporter/protocol"
@@ -78,6 +80,9 @@ func printVersion() {
 
 func startServer() {
 	log.Infof("Starting bird exporter (Version: %s)", version)
+	if err := validateListenAddress(*listenAddress); err != nil {
+		log.Fatal(err)
+	}
 
 	if !*newFormat {
 		log.Info("INFO: You are using the old metric format. Please consider using the new (more convenient one) by setting -format.new=true.")
@@ -144,18 +149,42 @@ func newHTTPServer(address string, handler http.Handler) *http.Server {
 	}
 }
 
+func validateListenAddress(address string) error {
+	if address == "" || strings.TrimSpace(address) != address {
+		return fmt.Errorf("web listen address must be a non-empty host:port: %q", address)
+	}
+
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("invalid web listen address %q: %w", address, err)
+	}
+	if port == "" {
+		return fmt.Errorf("web listen address must include a port: %q", address)
+	}
+	if _, err := net.LookupPort("tcp", port); err != nil {
+		return fmt.Errorf("invalid web listen port %q: %w", port, err)
+	}
+
+	return nil
+}
+
+func newPrometheusHandler(gatherer prometheus.Gatherer) http.Handler {
+	l := log.New()
+	l.Level = log.ErrorLevel
+
+	return promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{
+		ErrorLog:      l,
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	})
+}
+
 func handleMetricsRequest(w http.ResponseWriter, r *http.Request) {
 	reg := prometheus.NewRegistry()
 	p := enabledProtocols()
 	c := NewMetricCollector(*newFormat, p, *descriptionLabels, *birdSocket)
 	reg.MustRegister(c)
 
-	l := log.New()
-	l.Level = log.ErrorLevel
-	promhttp.HandlerFor(reg, promhttp.HandlerOpts{
-		ErrorLog:      l,
-		ErrorHandling: promhttp.ContinueOnError,
-	}).ServeHTTP(w, r)
+	newPrometheusHandler(reg).ServeHTTP(w, r)
 }
 
 func enabledProtocols() protocol.Proto {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPServerHasResourceTimeouts(t *testing.T) {
+	server := newHTTPServer("127.0.0.1:0", http.NewServeMux())
+
+	if server.ReadHeaderTimeout != serverReadHeaderTimeout ||
+		server.ReadTimeout != serverReadTimeout ||
+		server.WriteTimeout != serverWriteTimeout ||
+		server.IdleTimeout != serverIdleTimeout ||
+		server.MaxHeaderBytes != serverMaxHeaderBytes {
+		t.Fatalf("unexpected server limits: %+v", server)
+	}
+}
+
+func TestHTTPMuxRejectsUnexpectedRoutesAndMethods(t *testing.T) {
+	metricsCalled := false
+	mux := newHTTPMux("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		metricsCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantAllow  string
+	}{
+		{name: "root", method: http.MethodGet, path: "/", wantStatus: http.StatusOK},
+		{name: "unknown path", method: http.MethodGet, path: "/debug", wantStatus: http.StatusNotFound},
+		{name: "root method", method: http.MethodPost, path: "/", wantStatus: http.StatusMethodNotAllowed, wantAllow: "GET, HEAD"},
+		{name: "metrics method", method: http.MethodPost, path: "/metrics", wantStatus: http.StatusMethodNotAllowed, wantAllow: "GET"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(test.method, test.path, nil)
+			mux.ServeHTTP(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", response.Code, test.wantStatus)
+			}
+			if response.Header().Get("Allow") != test.wantAllow {
+				t.Fatalf("Allow = %q, want %q", response.Header().Get("Allow"), test.wantAllow)
+			}
+		})
+	}
+
+	if metricsCalled {
+		t.Fatal("metrics handler called for rejected method")
+	}
+}
+
+func TestHTTPMuxServesMetrics(t *testing.T) {
+	metricsCalled := false
+	mux := newHTTPMux("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		metricsCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	mux.ServeHTTP(response, request)
+
+	if !metricsCalled || response.Code != http.StatusNoContent {
+		t.Fatalf("metricsCalled = %v, status = %d", metricsCalled, response.Code)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,30 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+var invalidMetricDesc = prometheus.NewDesc(
+	"bird_exporter_invalid_test_metric",
+	"Test-only invalid metric.",
+	nil,
+	nil,
+)
+
+type invalidCollector struct{}
+
+func (*invalidCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- invalidMetricDesc
+}
+
+func (*invalidCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.NewInvalidMetric(invalidMetricDesc, errors.New("invalid test metric"))
+}
 
 func TestHTTPServerHasResourceTimeouts(t *testing.T) {
 	server := newHTTPServer("127.0.0.1:0", http.NewServeMux())
@@ -71,5 +91,48 @@ func TestHTTPMuxServesMetrics(t *testing.T) {
 
 	if !metricsCalled || response.Code != http.StatusNoContent {
 		t.Fatalf("metricsCalled = %v, status = %d", metricsCalled, response.Code)
+	}
+}
+
+func TestPrometheusHandlerFailsClosedOnGatherError(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(&invalidCollector{})
+
+	response := httptest.NewRecorder()
+	newPrometheusHandler(registry).ServeHTTP(
+		response,
+		httptest.NewRequest(http.MethodGet, "/metrics", nil),
+	)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestValidateListenAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{name: "all interfaces", address: ":9324"},
+		{name: "IPv4 loopback", address: "127.0.0.1:9324"},
+		{name: "IPv6 loopback", address: "[::1]:9324"},
+		{name: "service port", address: "localhost:http"},
+		{name: "empty", address: "", wantErr: true},
+		{name: "missing port", address: "127.0.0.1", wantErr: true},
+		{name: "empty port", address: "127.0.0.1:", wantErr: true},
+		{name: "unbracketed IPv6", address: "::1:9324", wantErr: true},
+		{name: "unknown service", address: "127.0.0.1:not-a-service", wantErr: true},
+		{name: "surrounding whitespace", address: " 127.0.0.1:9324", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateListenAddress(tt.address)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateListenAddress(%q) error = %v, wantErr = %v", tt.address, err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What changed

- replace the unbounded HTTP convenience servers with an explicit `http.Server` that has header, read, write, idle, and header-size limits
- use a private mux with exact routes and reject unsupported methods before invoking the metrics collector
- validate the configured listen address before startup
- make the metrics endpoint return an HTTP error when Prometheus gathering detects an invalid or inconsistent metric instead of silently serving partial output
- handle landing-page write failures and add regression tests for server limits, routes, methods, invalid addresses, and gather failures
- require Go 1.26.5 and add pinned CI jobs for module verification, race detection, vet, `govulncheck`, and `gosec`
- pin every GitHub Action, Helm, Cosign, and container base image to reviewed versions or immutable commit/digest references
- replace `ADD .` with a default-deny Docker context and explicit source copies
- build multi-architecture, non-root images without a shell dependency and publish provenance, SBOM, and keyless signatures
- point the Helm chart at the existing `ghcr.io/czerwonk/bird_exporter:v1.5.0` image and harden the pod with no service-account token, RuntimeDefault seccomp, and no privilege escalation
- add a private vulnerability-reporting policy and Docker Dependabot coverage

## Why

The previous HTTP server had no resource timeouts. An invalid listen address was discovered only when the server goroutine failed, and Prometheus's default HTTP handler could continue with partial output after descriptor or gather errors. The Docker workflow used an Actions runtime that no longer runs on GitHub-hosted runners, mutable action/base-image references, and a repository-wide build context. The chart default referenced Docker Hub tags that do not exist, while the released image is available in GHCR. The container also ran as root and the pod inherited an unnecessary Kubernetes API token.

Running `govulncheck` with the locally installed Go 1.26.2 found four reachable standard-library advisories; all are fixed by Go 1.26.5. The updated `go` directive and `setup-go` configuration keep local and CI builds on that patch level or newer.

## Compatibility and deployment impact

Existing exporter flags, metrics, and the default `:9324` listen address are unchanged. The HTTP endpoint now serves only `/`, the configured metrics path, and their supported methods. Invalid listen addresses fail fast. Gather-time metric inconsistencies fail closed with HTTP 500 rather than returning a misleading partial scrape.

The container runs as UID/GID 1000; operators must grant that identity only the supplemental group needed for the BIRD control socket. The chart's default `fsGroup` remains configurable.

The chart version becomes `0.1.4` and its default image changes from a missing Docker Hub tag to `ghcr.io/czerwonk/bird_exporter:v1.5.0`.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=3 ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `govulncheck@v1.6.0 ./...`: no vulnerabilities with Go 1.26.5
- `gosec@v2.28.0 ./...`: 0 issues
- `actionlint@v1.7.7`: all workflows pass
- Helm v3.21.3: `lint`, `template`, and `package` pass
- GoReleaser v2.17.1: configuration check and seven-target snapshot pass
- standalone Linux `arm/v7` cross-build passes

`staticcheck@v0.7.0` retains two pre-existing raw-regexp style findings in `parser/ospf.go`; those lines are corrected by the independent parser PR #142. No Docker daemon was available on the audit host, so the PR does not claim a local OCI build or image vulnerability scan.
