### PR TITLE
Add go install to INSTALL section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ In version 0.8 communication to bird changed to sockets. The default socket path
 ```
 go get -u github.com/czerwonk/bird_exporter
 ```
+or
+```
+go install github.com/czerwonk/bird_exporter@latest 
+```
 
 ## Kubernetes
 


### PR DESCRIPTION
Motivation
  - installing without cloning fails with
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```